### PR TITLE
Fix kcompose topic alter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ kcompose env
 
 ## Changelog
 
+### 0.8.1
+
+ - \[Bug\] Fix problem in `kcompose topic alter`: 
+
 ### 0.8.0
 
  - Updated kafka to 2.7.0

--- a/kcompose.sh
+++ b/kcompose.sh
@@ -196,12 +196,12 @@ case $1 in
         ${kafkaBinaries}/kafka-topics.sh --bootstrap-server $broker --command-config $credentialsFile --describe --topic $topic $*
         ;;
     "alter")
-        helpText="Usage: $programName topic alter TOPIC"
+        helpText="Usage: $programName topic alter TOPIC [options]"
         checkNArgs $3
         topic=$3
         shift 3
         options=$*
-        ${kafkaBinaries}/kafka-topics.sh --bootstrap-server $broker --command-config $credentialsFile --alter --topic $topic $options
+        ${kafkaBinaries}/kafka-configs.sh --bootstrap-server $broker --command-config $credentialsFile --alter --topic $topic $options
         ;;
     "remove")
         helpText="Usage: $programName topic remove TOPIC"


### PR DESCRIPTION
The command `kcompose topic alter` was broken, showing the error:

Option combination "[bootstrap-server],[config]" can't be used with option "[alter]"

Seems related to [this issue](https://issues.apache.org/jira/browse/KAFKA-9773).

Changing from kafka-topics.sh to kafka-configs.sh fixed the issue.