### PR TITLE
Change egrep call to grep -E

### DIFF
--- a/kafka/bin/kafka-run-class.sh
+++ b/kafka/bin/kafka-run-class.sh
@@ -38,7 +38,7 @@ should_include_file() {
     return 0
   fi
   file=$1
-  if [ -z "$(echo "$file" | egrep "$regex")" ] ; then
+  if [ -z "$(echo "$file" | grep -E "$regex")" ] ; then
     return 0
   else
     return 1


### PR DESCRIPTION
egrep command has been flaged as obsolete.

Warning message prompted when using kcompose:

egrep: warning: egrep is obsolescent; using grep -E

![image](https://github.com/arquivei/kcompose/assets/322159/79a91ce1-beeb-448b-9876-1b3172657078)


Reference: https://www.shellcheck.net/wiki/SC2196